### PR TITLE
タグのボタンアクションが発行されない問題を修正

### DIFF
--- a/qiita-reader-ios/QiitaReader/Screen/QiitaSearch/View/TagCloudView.swift
+++ b/qiita-reader-ios/QiitaReader/Screen/QiitaSearch/View/TagCloudView.swift
@@ -42,6 +42,7 @@ private struct TagButtonView: View {
                 .background(Color.gray.opacity(0.1))
                 .clipShape(.rect(cornerRadius: 8))
         })
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🐛 バグ  

<br />

**バグ内容**
- Listのアイテムをタップすると全てのタグボタンのアクションが実行される
- タグの部分をタップしてもListのアイテムをタップしたと見なされる

## やったこと
- TagButtonViewに.buttonStyle(.plain)を設定

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- Listアイテムのタグをタップしたときにタグ毎にアクションが実行されること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->

### 参考記事
- https://blog.smartbank.co.jp/entry/2023/08/30/swiftui-touch-target-size
- https://qiita.com/yoshitaka/items/b499306ec095e3dc0961
- [HIG - Buttonタップ領域は44*44p確保されるようになっている](https://developer.apple.com/design/human-interface-guidelines/accessibility#Buttons-and-controls)


### 考察
親View（List）のアクションが優先されて、そのアクションイベントが全ての子View（TagButtonView）に伝搬されるようになっている。.buttonStyle(.plain)を設定することで独自のタップエリアを持つUIコンポーネントとして宣言され、親Viewのタップイベントが反映されないようになるよう。
